### PR TITLE
Don't check if result is not false or nil

### DIFF
--- a/lib/speed_king/i18n_cache.rb
+++ b/lib/speed_king/i18n_cache.rb
@@ -11,7 +11,7 @@ module I18nCache
 
     cache[cache_key] || begin
       result = super
-      cache[cache_key] = result if result
+      cache[cache_key] = result
       result
     end
   end


### PR DESCRIPTION
May I suggest that we don't check if result is not nil or false?
As far as I know (please CMIIW), `I18n.t` will not return falsey value.
Edit:
If the lookup returns 'translation missing' then it's even more important to cache it since a missing translation is the most exhaustive lookup. So, there is no need to check if the result is not 'translation missing' either.